### PR TITLE
Using swap to exchange when sorting

### DIFF
--- a/libnestutil/sort.h
+++ b/libnestutil/sort.h
@@ -26,32 +26,12 @@
 #include <deque>
 #include <vector>
 #include <cstddef>
+#include <utility>
 
 #define INSERTION_SORT_CUTOFF 10 // use insertion sort for smaller arrays
 
 namespace nest
 {
-/**
- * Exchanges elements i and j in vector vec.
- */
-template < typename T >
-inline void
-exchange_( std::vector< T >& vec, const size_t i, const size_t j )
-{
-  const T tmp = vec[ i ];
-  vec[ i ] = vec[ j ];
-  vec[ j ] = tmp;
-}
-
-template < typename T >
-inline void
-exchange_( std::deque< T >& vec, const size_t i, const size_t j )
-{
-  const T tmp = vec[ i ];
-  vec[ i ] = vec[ j ];
-  vec[ j ] = tmp;
-}
-
 /**
  * Calculates the median of three elements.
  * See http://algs4.cs.princeton.edu/23quicksort/QuickX.java.html.
@@ -99,8 +79,8 @@ insertion_sort( std::vector< T1 >& vec_sort,
     for ( size_t j = i; ( j > lo ) and ( vec_sort[ j ] < vec_sort[ j - 1 ] );
           --j )
     {
-      exchange_( vec_sort, j, j - 1 );
-      exchange_( vec_perm, j, j - 1 );
+      std::swap( vec_sort[ j ], vec_sort[ j - 1 ] );
+      std::swap( vec_perm[ j ], vec_perm[ j - 1 ] );
     }
   }
 }
@@ -118,8 +98,8 @@ insertion_sort( std::vector< T1 >& vec_sort,
     for ( size_t j = i; ( j > lo ) and ( vec_sort[ j ] < vec_sort[ j - 1 ] );
           --j )
     {
-      exchange_( vec_sort, j, j - 1 );
-      exchange_( vec_perm, j, j - 1 );
+      std::swap( vec_sort[ j ], vec_sort[ j - 1 ] );
+      std::swap( vec_perm[ j ], vec_perm[ j - 1 ] );
     }
   }
 }
@@ -136,8 +116,8 @@ insertion_sort( std::deque< T1 >& vec_sort,
     for ( size_t j = i; ( j > lo ) and ( vec_sort[ j ] < vec_sort[ j - 1 ] );
           --j )
     {
-      exchange_( vec_sort, j, j - 1 );
-      exchange_( vec_perm, j, j - 1 );
+      std::swap( vec_sort[ j ], vec_sort[ j - 1 ] );
+      std::swap( vec_perm[ j ], vec_perm[ j - 1 ] );
     }
   }
 }
@@ -184,8 +164,8 @@ quicksort3way( std::vector< T1 >& vec_sort,
   }
 
   // move pivot to the front
-  exchange_( vec_sort, m, lo );
-  exchange_( vec_perm, m, lo );
+  std::swap( vec_sort[ m ], vec_sort[ lo ] );
+  std::swap( vec_perm[ m ], vec_perm[ lo ] );
 
   // Dijkstra's three-way-sort
   size_t lt = lo;
@@ -198,8 +178,8 @@ quicksort3way( std::vector< T1 >& vec_sort,
   {
     ++i;
   }
-  exchange_( vec_sort, lo, i - 1 );
-  exchange_( vec_perm, lo, i - 1 );
+  std::swap( vec_sort[ lo ], vec_sort[ i - 1 ] );
+  std::swap( vec_perm[ lo ], vec_perm[ i - 1 ] );
   lt = i - 1;
 
   // adjust position of gt (useful for sorted arrays)
@@ -212,15 +192,15 @@ quicksort3way( std::vector< T1 >& vec_sort,
   {
     if ( vec_sort[ i ] < v )
     {
-      exchange_( vec_sort, lt, i );
-      exchange_( vec_perm, lt, i );
+      std::swap( vec_sort[ lt ], vec_sort[ i ] );
+      std::swap( vec_perm[ lt ], vec_perm[ i ] );
       ++lt;
       ++i;
     }
     else if ( vec_sort[ i ] > v )
     {
-      exchange_( vec_sort, i, gt );
-      exchange_( vec_perm, i, gt );
+      std::swap( vec_sort[ i ], vec_sort[ gt ] );
+      std::swap( vec_perm[ i ], vec_perm[ gt ] );
       --gt;
     }
     else
@@ -267,8 +247,8 @@ quicksort3way( std::vector< T1 >& vec_sort,
   }
 
   // move pivot to the front
-  exchange_( vec_sort, m, lo );
-  exchange_( vec_perm, m, lo );
+  std::swap( vec_sort[ m ], vec_sort[ lo ] );
+  std::swap( vec_perm[ m ], vec_perm[ lo ] );
 
   // Dijkstra's three-way-sort
   size_t lt = lo;
@@ -281,8 +261,8 @@ quicksort3way( std::vector< T1 >& vec_sort,
   {
     ++i;
   }
-  exchange_( vec_sort, lo, i - 1 );
-  exchange_( vec_perm, lo, i - 1 );
+  std::swap( vec_sort[ lo ], vec_sort[ i - 1 ] );
+  std::swap( vec_perm[ lo ], vec_perm[ i - 1 ] );
   lt = i - 1;
 
   // adjust position of gt (useful for sorted arrays)
@@ -295,15 +275,15 @@ quicksort3way( std::vector< T1 >& vec_sort,
   {
     if ( vec_sort[ i ] < v )
     {
-      exchange_( vec_sort, lt, i );
-      exchange_( vec_perm, lt, i );
+      std::swap( vec_sort[ lt ], vec_sort[ i ] );
+      std::swap( vec_perm[ lt ], vec_perm[ i ] );
       ++lt;
       ++i;
     }
     else if ( vec_sort[ i ] > v )
     {
-      exchange_( vec_sort, i, gt );
-      exchange_( vec_perm, i, gt );
+      std::swap( vec_sort[ i ], vec_sort[ gt ] );
+      std::swap( vec_perm[ i ], vec_perm[ gt ] );
       --gt;
     }
     else
@@ -350,8 +330,8 @@ quicksort3way( std::deque< T1 >& vec_sort,
   }
 
   // move pivot to the front
-  exchange_( vec_sort, m, lo );
-  exchange_( vec_perm, m, lo );
+  std::swap( vec_sort[ m ], vec_sort[ lo ] );
+  std::swap( vec_perm[ m ], vec_perm[ lo ] );
 
   // Dijkstra's three-way-sort
   size_t lt = lo;
@@ -364,8 +344,8 @@ quicksort3way( std::deque< T1 >& vec_sort,
   {
     ++i;
   }
-  exchange_( vec_sort, lo, i - 1 );
-  exchange_( vec_perm, lo, i - 1 );
+  std::swap( vec_sort[ lo ], vec_sort[ i - 1 ] );
+  std::swap( vec_perm[ lo ], vec_perm[ i - 1 ] );
   lt = i - 1;
 
   // adjust position of gt (useful for sorted arrays)
@@ -378,15 +358,15 @@ quicksort3way( std::deque< T1 >& vec_sort,
   {
     if ( vec_sort[ i ] < v )
     {
-      exchange_( vec_sort, lt, i );
-      exchange_( vec_perm, lt, i );
+      std::swap( vec_sort[ lt ], vec_sort[ i ] );
+      std::swap( vec_perm[ lt ], vec_perm[ i ] );
       ++lt;
       ++i;
     }
     else if ( vec_sort[ i ] > v )
     {
-      exchange_( vec_sort, i, gt );
-      exchange_( vec_perm, i, gt );
+      std::swap( vec_sort[ i ], vec_sort[ gt ] );
+      std::swap( vec_perm[ i ], vec_perm[ gt ] );
       --gt;
     }
     else


### PR DESCRIPTION
Profiling showed that most of the slowdown when sorting in the initial simulation was due to exchanging elements in the deque. This PR speeds up the exchange by using `std::swap`, leading to a ~40% speed-up of the initial simulation. It's still slower than using vectors, though.