### PR TITLE
Update connection management doc

### DIFF
--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -268,7 +268,7 @@ dictionary specifying the synapse parameters in more detail.
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', n)
     nest.Connect(A, B, syn_spec='static_synapse')
-    
+
     syn_spec_dict = {'synapse_model': 'stdp_synapse', 'weight': 2.5, 'delay': 0.5})
     nest.Connect(A, B, syn_spec=syn_spec_dict)
 
@@ -672,7 +672,7 @@ more detailed information about each of them can be found in the
    Not all nodes can be connected via all available synapse types. The
    events a synapse type is able to transmit is documented in the
    ``Transmits`` section of the model documentation.
-     
+
 All synapses store their parameters on a per-connection basis.
 However, each of the built-in models is registered with the simulation
 kernel in a number of different ways that slightly modify the
@@ -748,7 +748,7 @@ like what was intended, it is oftentimes useful to inspect the
 connections in the network. For this, NEST provides the function
 
 ::
-   
+
   nest.GetConnections(source=None, target=None, synapse_model=None, synapse_label=None)
 
 This function returns a ``SynapseCollection`` object that contains the

--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -11,21 +11,24 @@ Connections between populations of neurons and between neurons and
 devices for stimulation and recording in NEST are created with the
 ``Connect()`` function. Although each connection is internally
 represented individually, you can use a single call to ``Connect()``
-to create many connections at the same time.
+to create many connections at the same time. In the simplest case, the
+function takes two NodeCollections containing the source and target
+nodes that will be connected in an all-to-all fashion. These two first
+arguments are mandatory.
 
 Each call to the function will establish the connectivity between pre-
 and post-synaptic populations according to a certain pattern or
 rule. The desired pattern is specified by simply stating the rule name
-as third argument to ``Connect()``, or by setting the key *rule* in
-the *connectivity specification* dictionary ``conn_spec``, alongside
+as third argument to ``Connect()``, or by setting the key `rule` in
+the `connectivity specification` dictionary ``conn_spec`` alongside
 additional rule-specific parameters. All available patterns are
 described in the section :ref:`Connection Rules <conn_rules>` below.
 
-To specify the properties for the individual connections, a *synapse
-specification* ``syn_spec`` can be given to ``Connect()``. This can
+To specify the properties for the individual connections, a `synapse
+specification` ``syn_spec`` can be given to ``Connect()``. This can
 also just be a the name of the synapse model to be used, an object
 defining :ref:`collocated synapses <collocated_synapses>`, or a
-dictionary, with the mandatory key *synapse_model* as well as optional
+dictionary, with the mandatory key `synapse_model` as well as optional
 parameters for the connections. The ``syn_spec`` is given as the
 fourth argument to the ``Connect()`` function. Parameters like the
 synaptic weight or delay can be either set values or drawn and
@@ -87,8 +90,8 @@ Connection rules are specified using the ``conn_spec`` parameter of
 rule, or a dictionary containing a rule specification. Only connection
 rules requiring no parameters can be given as strings, for all other
 rules, a dictionary specifying the rule and its parameters is
-required. Examples for such parameters might be in- or out-degrees, or
-a probability for establishing a connection.
+required. Examples for such parameters might be in- and out-degrees,
+or the probability for establishing a connection.
 
 all-to-all
 ~~~~~~~~~~
@@ -106,7 +109,7 @@ specified.
     n, m = 10, 12
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
-    nest.Connect(A, B, 'all-to-all')
+    nest.Connect(A, B, 'all_to_all')
     nest.Connect(A, B)  # equivalent
 
 .. _conn_builder_conngen:
@@ -130,18 +133,20 @@ pattern in a library-specific way. The Connection Generator is handed
 to ``Connect()`` under the key `cg` of the connection specification
 dictionary and evaluated internally. If the Connection Generator
 provides values for connection weights and delays, their respective
-indices can be specified under the key `params_map`.
+indices can be specified under the key `params_map`. Alternatively,
+all synapse parameters can be specified using the synapse
+specification argument to ``Connect()``
 
 The following listing shows an example for using the `Connection-Set
 Algebra <https://github.com/INCF/csa>`_ in NEST via the Connection
 Generator Interface and randomly connects 10% of the neurons from
-``pre`` to the neurons in ``post``, each connection having a weight of
+``A`` to the neurons in ``B``, each connection having a weight of
 10000.0 pA and a delay of 1.0 ms:
 
 ::
 
-   pre = nest.Create('iaf_psc_alpha', 100)
-   post = nest.Create('iaf_psc_alpha', 100)
+   A = nest.Create('iaf_psc_alpha', 100)
+   B = nest.Create('iaf_psc_alpha', 100)
 
    # Create the Connection Generator object
    import csa
@@ -150,8 +155,8 @@ Generator Interface and randomly connects 10% of the neurons from
    # Map weight and delay indices to vaules from cg
    params_map = {'weight': 0, 'delay': 1}
 
-   conn_dict = {'rule': 'conngen', 'cg': cg, 'params_map': params_map}
-   nest.Connect(pre, post, conn_dict)
+   conn_spec_dict = {'rule': 'conngen', 'cg': cg, 'params_map': params_map}
+   nest.Connect(A, B, conn_spec_dict)
 
 fixed indegree
 ~~~~~~~~~~~~~~
@@ -168,8 +173,8 @@ that each node in ``B`` has a fixed `indegree` of ``N``.
     n, m, N = 10, 12, 2
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
-    conn_dict = {'rule': 'fixed_indegree', 'indegree': N}
-    nest.Connect(A, B, conn_dict)
+    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': N}
+    nest.Connect(A, B, conn_spec_dict)
 
 fixed outdegree
 ~~~~~~~~~~~~~~~
@@ -186,13 +191,13 @@ that each node in ``A`` has a fixed `outdegree` of ``N``.
     n, m, N = 10, 12, 2
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
-    conn_dict = {'rule': 'fixed_outdegree', 'outdegree': N}
-    nest.Connect(A, B, conn_dict)
+    conn_spec_dict = {'rule': 'fixed_outdegree', 'outdegree': N}
+    nest.Connect(A, B, conn_spec_dict)
 
 fixed total number
 ~~~~~~~~~~~~~~~~~~
 
-The nodes in ``pre`` are randomly connected with the nodes in ``post``
+The nodes in ``pre`` are randomly connected with the nodes in ``B``
 such that the total number of connections equals ``N``.
 
 ::
@@ -200,8 +205,8 @@ such that the total number of connections equals ``N``.
     n, m, N = 10, 12, 30
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
-    conn_dict = {'rule': 'fixed_total_number', 'N': N}
-    nest.Connect(A, B, conn_dict)
+    conn_spec_dict = {'rule': 'fixed_total_number', 'N': N}
+    nest.Connect(A, B, conn_spec_dict)
 
 one-to-one
 ~~~~~~~~~~
@@ -232,8 +237,8 @@ created with probability ``p``.
     n, m, p = 10, 12, 0.2
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
-    conn_dict = {'rule': 'pairwise_bernoulli', 'p': p}
-    nest.Connect(A, B, conn_dict)
+    conn_spec_dict = {'rule': 'pairwise_bernoulli', 'p': p}
+    nest.Connect(A, B, conn_spec_dict)
 
 symmetric pairwise bernoulli
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -241,17 +246,17 @@ symmetric pairwise bernoulli
 For each possible pair of nodes from ``A`` and ``B``, a connection is
 created with probability ``p`` from ``A`` to ``B``, as well as a
 connection from ``B`` to ``A`` (two connections in total). To use the
-'symmetric_pairwise_bernoulli' rule, ``allow_autapses`` must be
-`False`, and ``make_symmetric`` must be `True`.
+this rule, ``allow_autapses`` must be `False`, and ``make_symmetric``
+must be `True`.
 
 ::
 
     n, m, p = 10, 12, 0.2
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
-    conn_dict = {'rule': 'symmetric_pairwise_bernoulli', 'p': p,
+    conn_spec_dict = {'rule': 'symmetric_pairwise_bernoulli', 'p': p,
                  'allow_autapses': False, 'make_symmetric': True}
-    nest.Connect(A, B, conn_dict)
+    nest.Connect(A, B, conn_spec_dict)
 
 .. _synapse_spec:
 
@@ -272,15 +277,16 @@ dictionary specifying the synapse parameters in more detail.
     syn_spec_dict = {'synapse_model': 'stdp_synapse', 'weight': 2.5, 'delay': 0.5})
     nest.Connect(A, B, syn_spec=syn_spec_dict)
 
-Specifying the synapse properties as a collocated synapses or in a
-single dictionary allows to draw synaptic parameters from random
-distributions and combine such parameters flexibly. In addition to the
-key ``synapse_model``, the dictionary can contain specifications for
-``weight``, ``delay``, ``receptor_type`` (see :ref:`receptor-types`
-for details) and parameters specific to the chosen synapse model. The
-specification of all parameters is optional and unspecified parameters
-will take on the default values of the chosen synapse model. These
-defaults can be inspected using ``nest.GetDefaults(synapse_model)``.
+Specifying the synapse properties in a single dictionary or as
+:ref:`collocated synapses <collocated_synapses>` allows to draw
+synaptic parameters from random distributions and combine such
+parameters flexibly. In addition to the key ``synapse_model``, the
+dictionary can contain specifications for ``weight``, ``delay``,
+``receptor_type`` (see :ref:`receptor-types` for details) and
+parameters specific to the chosen synapse model. The specification of
+all parameters is optional and unspecified parameters will take on the
+default values of the chosen synapse model that can be inspected using
+``nest.GetDefaults(synapse_model)``.
 
 All parameters can be either scalars, arrays or distributions
 (specified as a ``nest.Parameter``). One synapse dictionary can
@@ -317,8 +323,8 @@ specified as arrays of the correct type.
 all-to-all
 ^^^^^^^^^^
 
-When connecting ``all_to_all``, the array parameter must have
-dimension `len(post) x len(pre)`.
+When connecting with rule ``all_to_all``, the array parameter must
+have dimension `len(B) x len(A)`.
 
 ::
 
@@ -331,7 +337,7 @@ fixed indegree
 ^^^^^^^^^^^^^^
 
 For rule ``fixed_indegree`` the array has to be a two-dimensional
-NumPy array or Python list with shape `(len(post), indegree)`, where
+NumPy array or Python list with shape `(len(B), indegree)`, where
 `indegree` is the number of incoming connections per target neuron.
 This means that the rows describe the target, while the columns
 represent the connections converging on the target neuron, regardless
@@ -462,14 +468,28 @@ For further information on the available distributions see
 Collocated synapses
 ~~~~~~~~~~~~~~~~~~~
 
-Sometimes it is useful to create several connections with different
-synapse types simultaneously. To create such `collocated synapses`, an
-object of type ``CollocatedSynapses`` must be used as the ``syn_spec``
-in the call to ``Connect``. The constructor ``CollocatedSynapses()``
-takes synapse specification dictionaries as arguments and the given
-dictionaries will be applied to each source-target pair.
+Some modeling applications require multiple connections between the
+same pairs of nodes. An example of this could be a network, where each
+pre-synaptic neuron connects with a static synapse to a modulatory
+receptor on the post-synaptic neuron and with a plastic synapse to a
+normal NMDA-type receptor.
 
-  ::
+This type of connectivity is especially hard to realize when using
+randomized connection rules, as the chosen pairs that are actually
+connected are only known internally, or have to be retrieved manually
+after the call to ``Connect()`` returns.
+
+To ease the setup of such connectivity patterns, NEST supports a
+concept called `collocated synapses`. This allows to create several
+connections between chosen pairs of neurons (possibly with different
+synapse types or parameters) in a single call to ``nest.Connect()``.
+
+To create collocated synapses, the synapse specification consists of
+an object of type ``CollocatedSynapses``, whose constructor takes
+synapse specification dictionaries as arguments and applies the given
+dictionaries to each source-target pair internally.
+
+::
 
     nodes = nest.Create('iaf_psc_alpha', 3)
     syn_spec = nest.CollocatedSynapses({'weight': 4.0, 'delay': 1.5},
@@ -478,20 +498,23 @@ dictionaries will be applied to each source-target pair.
     nest.Connect(nodes, nodes, conn_spec='one_to_one', syn_spec=syn_spec)
     print(nest.GetConnections().alpha)
 
-The example above will create 9 connections in total.
-* 3 use the default model ``static_synapse`` with a `weight` of 4.0
-  and `delay` of 1.5
-* 6 use the model `stdp_synapse`. Of these,
-  * 3 will have the default value for parameter `alpha`
-  * 3 will have an `alpha` of 3.0.
+The example above will create 9 connections in total because there are
+3 neurons times 3 synapse specifications in the ``CollocatedSynapses``
+object.
 
   >>> print(nest.GetKernelStatus('num_connections'))
   9
 
+In more detail, the connections have the following properties:
+
+* 3 are of type ``static_synapse`` with `weight` 4.0 and `delay` 1.5
+* 3 are of type ``stdp_synapse`` with the default value for `alpha`
+* 3 are of type ``stdp_synapse`` with an `alpha` of 3.0.
+
 If you want to connect with different :ref:`receptor types
 <receptor-types>`, you can do the following:
 
-  ::
+::
 
     A = nest.Create('iaf_psc_exp_multisynapse', 7)
     B = nest.Create('iaf_psc_exp_multisynapse', 7, {'tau_syn': [0.1 + i for i in range(7)]})
@@ -509,17 +532,19 @@ your `CollocatedSynapses` object:
 Spatially-structured networks
 -----------------------------
 
-If nodes are created so that they have a spatial arrangement, it is
-possible to create connections with attributes based on the nodes'
-positions. See :doc:`Spatially-structured networks <spatial/index>`
-for more information about how to create such networks.
+Nodes in NEST can be created so that they have a position in two- or
+three-dimentsional space. To take full advantage of the arrangement of
+nodes, connection parameters can be based on the nodes' positions or
+their spatial relation to each other. See :doc:`Spatially-structured
+networks <spatial/index>` for the full information about how to create
+and connect such networks.
 
 Connecting sparse matrices with array indexing
 ----------------------------------------------
 
 Oftentimes, you will find yourself in a situation, where you want to
-base your connectivity on actual data instead of on rules. A common
-situation here is that you have a (sometimes sparse) connection matrix
+base your connectivity on actual data instead of rules. A common
+scenario is that you have a (sometimes sparse) connection matrix
 coming from an experiment or from a graph algorithm. Let's assume you
 have a weight matrix of the form:
 
@@ -532,16 +557,16 @@ have a weight matrix of the form:
     w_{1m} & w_{2m} & \cdots & w_{nm} \\
     \end{bmatrix}
 
-where :math:`w_{ij}` is the weight of the connection with presynaptic
-node :math:`i` and postsynaptic node :math:`j`. In all generality, we
+where :math:`w_{ij}` is the weight of the connection with pre-synaptic
+node :math:`i` and post-synaptic node :math:`j`. In all generality, we
 can assume that some weights are zero, indicating that there is no
 connection at all.
 
 As there is no support for creating connections from the whole matrix
-directly, we will instead just iterate the presynaptic neurons and
+directly, we will instead just iterate the pre-synaptic neurons and
 connect one column at a time. We assume that there are :math:`n`
-presynaptic nodes in the NodeCollection ``A`` and :math:`m`
-postsynaptic nodes in ``B``. We also assume that we have our weight
+pre-synaptic nodes in the NodeCollection ``A`` and :math:`m`
+post-synaptic nodes in ``B``. We also assume that we have our weight
 matrix given as a two-dimensional NumPy array `W`, with :math:`n`
 columns and :math:`m` rows.
 
@@ -559,7 +584,7 @@ columns and :math:`m` rows.
         weights = W[:, i]
 
         # To only connect pairs with a nonzero weight, we use array
-	# indexing to extract the weights and postsynaptic neurons.
+	# indexing to extract the weights and post-synaptic neurons.
         nonzero_indices = numpy.where(weights != 0)[0]
         weights = weights[nonzero_indices]
         post = B[nonzero_indices]
@@ -589,11 +614,12 @@ synaptic parameters available for each receptor. Please refer to the
 :doc:`model documentation <../models/index_neuron>` for details.
 
 In order to connect a pre-synaptic node to a certain receptor on a
-post-synaptic node, the integer ID of the receptor is given under the
-key ``receptor_type`` in the ``syn_spec`` dictionary when calling
-``Connect()``. If unspecified, the receptor will take on its default
-of 0. If you request a receptor that is not available in the target
-node, this will result in an error.
+post-synaptic node, the integer ID of the target receptor can be
+supplied under the key ``receptor_type`` in the ``syn_spec``
+dictionary during the call to ``Connect()``. If unspecified, the
+receptor will take on its default value of 0. If you request a
+receptor that is not available in the target node, this will result in
+a runtime error.
 
 To illustrate the concept of receptors in more detail, the following
 example shows how to connect several ``iaf_psc_alpha`` neurons to the
@@ -630,20 +656,20 @@ receptors.
     nest.Connect(A3, B, syn_spec={'receptor_type': receptors['proximal_exc']})
     nest.Connect(A4, B, syn_spec={'receptor_type': receptors['soma_inh']})
 
-In the example above, we inspect the receptors of the model by calling
-``nest.GetDefaults('iaf_cond_alpha_mc')['receptor_types']``.  This
-functionality is, however, only available for models with a predefined
-number of receptors, while models with a variable number of receptors
-usually don't provide such an enumeration.
+In the example above, we retrieve a map of available receptors and
+their IDs by extracting the `receptor_types` property from the model
+defaults. This functionality is, however, only available for models
+with a predefined number of receptors, while models with a variable
+number of receptors usually don't provide such an enumeration.
 
 An example for the latter are the `*_multisynapse` neuron models that
 support multiple individual synaptic time constants for the different
-receptors. In these models, the number of available receptors is
-determined by the length of the ``tau_syn`` vector that is supplied to
-the model instance. The following code snippet shows the setup and
-connection of such a model in more detail:
+receptors. In these models, the number of available receptors is not
+predefined, but determined only by the length of the ``tau_syn``
+vector that is supplied to the model instance. The following example
+shows the setup and connection of such a model in more detail:
 
-  ::
+::
 
     A = nest.Create('iaf_psc_alpha')
     B = nest.Create('iaf_psc_exp_multisynapse', params={'tau_syn': [0.1, 0.2, 0.3]})

--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -12,9 +12,8 @@ devices for stimulation and recording in NEST are created with the
 ``Connect()`` function. Although each connection is internally
 represented individually, you can use a single call to ``Connect()``
 to create many connections at the same time. In the simplest case, the
-function takes two NodeCollections containing the source and target
-nodes that will be connected in an all-to-all fashion. These two first
-arguments are mandatory.
+function just takes two NodeCollections containing the source and
+target nodes that will be connected in an all-to-all fashion.
 
 Each call to the function will establish the connectivity between pre-
 and post-synaptic populations according to a certain pattern or
@@ -26,15 +25,15 @@ described in the section :ref:`Connection Rules <conn_rules>` below.
 
 To specify the properties for the individual connections, a `synapse
 specification` ``syn_spec`` can be given to ``Connect()``. This can
-also just be a the name of the synapse model to be used, an object
+also just be the name of the synapse model to be used, an object
 defining :ref:`collocated synapses <collocated_synapses>`, or a
-dictionary, with the mandatory key `synapse_model` as well as optional
-parameters for the connections. The ``syn_spec`` is given as the
-fourth argument to the ``Connect()`` function. Parameters like the
-synaptic weight or delay can be either set values or drawn and
-combined flexibly from random distributions. More information about
-synapse models and their parameters can be found in the section
-:ref:`Synapse Specification <synapse_spec>`.
+dictionary, with optional parameters for the connections.
+
+The ``syn_spec`` is given as the fourth argument to the ``Connect()``
+function. Parameters like the synaptic weight or delay can be either
+set values or drawn and combined flexibly from random distributions.
+More information about synapse models and their parameters can
+be found in the section :ref:`Synapse Specification <synapse_spec>`.
 
 The ``Connect()`` function can be called in any of the following ways:
 
@@ -91,7 +90,8 @@ rule, or a dictionary containing a rule specification. Only connection
 rules requiring no parameters can be given as strings, for all other
 rules, a dictionary specifying the rule and its parameters is
 required. Examples for such parameters might be in- and out-degrees,
-or the probability for establishing a connection.
+or the probability for establishing a connection. A description of
+all connection rules available in NEST is available below.
 
 all-to-all
 ~~~~~~~~~~
@@ -197,7 +197,7 @@ that each node in ``A`` has a fixed `outdegree` of ``N``.
 fixed total number
 ~~~~~~~~~~~~~~~~~~
 
-The nodes in ``pre`` are randomly connected with the nodes in ``B``
+The nodes in ``A`` are randomly connected with the nodes in ``B``
 such that the total number of connections equals ``N``.
 
 ::
@@ -215,7 +215,7 @@ one-to-one
      :width: 200px
      :align: center
 
-The `i`th node in ``A`` is connected to the `i`th node in ``B``. The
+The `i`\ th node in ``A`` is connected to the `i`\ th node in ``B``. The
 NodeCollections of ``A`` and ``B`` have to contain the same number of
 nodes.
 
@@ -255,7 +255,7 @@ must be `True`.
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
     conn_spec_dict = {'rule': 'symmetric_pairwise_bernoulli', 'p': p,
-                 'allow_autapses': False, 'make_symmetric': True}
+                      'allow_autapses': False, 'make_symmetric': True}
     nest.Connect(A, B, conn_spec_dict)
 
 .. _synapse_spec:
@@ -288,8 +288,8 @@ all parameters is optional and unspecified parameters will take on the
 default values of the chosen synapse model that can be inspected using
 ``nest.GetDefaults(synapse_model)``.
 
-All parameters can be either scalars, arrays or distributions
-(specified as a ``nest.Parameter``). One synapse dictionary can
+All parameters can be either scalars, arrays or distributions.
+One synapse dictionary can
 contain an arbitrary combination of parameter types, as long as they
 are in agreement with the chosen connection rule.
 
@@ -434,7 +434,7 @@ For more information, check out the documentation on the different
     nest.Connect(A, B, syn_spec=syn_spec_dict)
 
 In this example, the default connection rule ``all_to_all`` is used
-and connections will be using the model `stdp_synapse`. All synapses
+and connections will be using synapse model `stdp_synapse`. All synapses
 are created with a static weight of 2.5 and a delay that is uniformly
 distributed in [0.8, 2.5]. The parameter `alpha` is drawn from a
 normal distribution with mean 5.0 and standard deviation 1.0, however,
@@ -476,11 +476,11 @@ normal NMDA-type receptor.
 
 This type of connectivity is especially hard to realize when using
 randomized connection rules, as the chosen pairs that are actually
-connected are only known internally, or have to be retrieved manually
+connected are only known internally, and have to be retrieved manually
 after the call to ``Connect()`` returns.
 
 To ease the setup of such connectivity patterns, NEST supports a
-concept called `collocated synapses`. This allows to create several
+concept called `collocated synapses`. This allows the creation of several
 connections between chosen pairs of neurons (possibly with different
 synapse types or parameters) in a single call to ``nest.Connect()``.
 
@@ -500,7 +500,7 @@ dictionaries to each source-target pair internally.
 
 The example above will create 9 connections in total because there are
 3 neurons times 3 synapse specifications in the ``CollocatedSynapses``
-object.
+object, and the connection rule ``one_to_one`` is used.
 
   >>> print(nest.GetKernelStatus('num_connections'))
   9
@@ -533,7 +533,7 @@ Spatially-structured networks
 -----------------------------
 
 Nodes in NEST can be created so that they have a position in two- or
-three-dimentsional space. To take full advantage of the arrangement of
+three-dimensional space. To take full advantage of the arrangement of
 nodes, connection parameters can be based on the nodes' positions or
 their spatial relation to each other. See :doc:`Spatially-structured
 networks <spatial/index>` for the full information about how to create
@@ -572,8 +572,8 @@ columns and :math:`m` rows.
 
 ::
 
-    W = np.array([[0.5 , 0.0, 1.5],
-                  [1.3 , 0.2, 0.0],
+    W = np.array([[0.5,  0.0, 1.5],
+                  [1.3,  0.2, 0.0],
                   [0.0, 1.25, 1.3]])
 
     A = nest.Create('iaf_psc_alpha', 3)
@@ -674,7 +674,7 @@ shows the setup and connection of such a model in more detail:
     A = nest.Create('iaf_psc_alpha')
     B = nest.Create('iaf_psc_exp_multisynapse', params={'tau_syn': [0.1, 0.2, 0.3]})
 
-    print(B.n_synapses)
+    print(B.n_synapses)   # This will print 3, as we set 3 different tau_syns
 
     nest.Connect(A, B, syn_spec={'receptor_type': 2})
 
@@ -879,7 +879,7 @@ Modifying Existing Connections
 
 To modify the parameters of an existing connection, you first have to
 obtain handles to them using ``nest.GetConnections()``. These handles
-can then be given as arguments to the ``nest.SetStatus()`` function.
+can then be given as arguments to the ``nest.SetStatus()`` function,
 or by using the ``set()`` function on the SynapseCollection directly:
 
 ::
@@ -914,7 +914,7 @@ connections in the SynapseCollection.
 
   >>>  conn.set(weight=[4.0, 4.5, 5.0, 5.5])
 
-Similar to how you can retrieve several parameters at once with the
+Similar to how you retrieve several parameters at once with the
 ``get()`` function explained above, you can also set multiple
 parameters at once using ``set(parameter_dictionary)``. Again, the
 values of the dictionary can be a single value, a list, or a

--- a/doc/guides/connection_management.rst
+++ b/doc/guides/connection_management.rst
@@ -7,27 +7,31 @@ Connection Management
    :local:
    :depth: 2
 
-Connections between populations of neurons and between neurons
-and devices for stimulating and recording are created with the
+Connections between populations of neurons and between neurons and
+devices for stimulation and recording in NEST are created with the
 ``Connect()`` function. Although each connection is internally
-represented as an individual object, you can use a single call to
-``Connect()`` to create many connections at the same time.
+represented individually, you can use a single call to ``Connect()``
+to create many connections at the same time.
 
-Each call to the function will establish the connectivity between
-the pre- and the post-synaptic population with a certain
-pattern. The desired pattern is specified by setting the key
-*rule* in the *connectivity specification* dictionary
-``conn_spec``, alongside with additional rule-specific
-parameters. All available patterns are described in the section
-:ref:`Connection Rules <conn_rules>`.
+Each call to the function will establish the connectivity between pre-
+and post-synaptic populations according to a certain pattern or
+rule. The desired pattern is specified by simply stating the rule name
+as third argument to ``Connect()``, or by setting the key *rule* in
+the *connectivity specification* dictionary ``conn_spec``, alongside
+additional rule-specific parameters. All available patterns are
+described in the section :ref:`Connection Rules <conn_rules>` below.
 
-The synapse model as well as parameters for the individual
-connections are defined in the *synapse specification* dictionary
-``syn_spec``. Parameters like the synaptic weight or delay can be
-either set values or drawn and combined flexibly from random
-distributions. All information about synapse models and their
-parameters can be found in the section :ref:`Synapse
-Specification <synapse_spec>`
+To specify the properties for the individual connections, a *synapse
+specification* ``syn_spec`` can be given to ``Connect()``. This can
+also just be a the name of the synapse model to be used, an object
+defining :ref:`collocated synapses <collocated_synapses>`, or a
+dictionary, with the mandatory key *synapse_model* as well as optional
+parameters for the connections. The ``syn_spec`` is given as the
+fourth argument to the ``Connect()`` function. Parameters like the
+synaptic weight or delay can be either set values or drawn and
+combined flexibly from random distributions. More information about
+synapse models and their parameters can be found in the section
+:ref:`Synapse Specification <synapse_spec>`.
 
 The ``Connect()`` function can be called in any of the following ways:
 
@@ -37,50 +41,54 @@ The ``Connect()`` function can be called in any of the following ways:
     Connect(pre, post, conn_spec)
     Connect(pre, post, conn_spec, syn_spec)
 
-``pre`` and ``post`` are ``NodeCollections`` defining the nodes of
-origin and termination.
+``pre`` and ``post`` are ``NodeCollections``, defining the nodes of
+origin (`sources`) and termination (`targets`) for the connections to
+be established.
 
-``conn_spec`` can either be a string containing the name of the
-connectivity rule (default: ``all_to_all``) or a dictionary specifying
-the rule name under the key `rule` and any rule-specific parameters, if needed.
+If ``conn_spec`` is not specified, the default connection rule
+``all_to_all`` will be used. When using a connection specification
+dictionary containing the rule name and rule-specific parameters, the
+additional switch ``allow_autapses`` (default: `True`) can be set to
+allow or disallow self-connections. Likewise, ``allow_multapses``
+(default: `True`) can be used to specify if multiple connections
+between the same pair of neurons are allowed or not.
 
-In addition, the switch ``allow_autapses`` (default: `True`) can be specified to allow 
-self-connections. Likewise, ``allow_multapses`` (default: `True`) specifies if multiple
-connections between the same pair of neurons are allowed. Please note that these
-switches are only confined to a single call to ``Connect()``, meaning that calling the
-function multiple times with the same set of neurons might still lead to a situation
-where these criterions are violated, even though the switches are set to `False` in
-each individual call.
+.. note::
 
-``syn_spec`` defines the synapse type and its properties. It can be
-given as a string defining the synapse model (default:
-'static_synapse'), as an object defining :ref:`collocated synapses <collocated_synapses>`,
-or as a dictionary with detailed synapse properties. By using the keyword variant
-(``Connect(pre, post, syn_spec=syn_spec_dict)``), ``conn_spec`` can be
-omitted in the call to ``Connect`` and will take on the default value of 
-'all_to_all'. More advanced uses of the synapse specification are described in
-:ref:`synapse_spec`.
+   The switches ``allow_autapses`` and ``allow_multapses`` are only
+   effective during each single call to ``Connect()``. Calling the
+   function multiple times with the same set of neurons might still
+   lead to violations of these constraints, even though the switches
+   were set to `False` in each individual call.
 
-After a connection is established, it might be beneficial to look up the number of
-connections in the network, which can be easily done using ``GetKernelStatus``:
+The synapse specification ``syn_spec`` defaults to the synapse model
+``static_synapse``. By using the keyword variant (``Connect(pre, post,
+syn_spec=syn_spec_dict)``), ``conn_spec`` can be omitted in the call
+to ``Connect()`` and will just take on the default value.
+
+After your connections are established, a quick sanity check is to
+look up the number of connections in the network, which can be easily
+done using ``GetKernelStatus()``:
 
 ::
 
     print(nest.GetKernelStatus('num_connections'))
 
-Have a look at the :ref:`inspecting_connections` section further down to
-get more tips on how to examine the connections.
+Have a look at the :ref:`inspecting_connections` section further down
+to get more tips on how to examine the connections in greater detail.
 
 .. _conn_rules:
 
 Connection Rules
 ----------------
 
-Connection rules are specified using the ``conn_spec`` parameter, which
-can be a string naming a connection rule or a dictionary containing a
-rule specification. Only connection rules requiring no parameters can be
-given as strings, for all other rules, a dictionary specifying the rule
-and its parameters, such as in- or out-degrees, is required.
+Connection rules are specified using the ``conn_spec`` parameter of
+``Connect()``, which can be either just a string naming a connection
+rule, or a dictionary containing a rule specification. Only connection
+rules requiring no parameters can be given as strings, for all other
+rules, a dictionary specifying the rule and its parameters is
+required. Examples for such parameters might be in- or out-degrees, or
+a probability for establishing a connection.
 
 all-to-all
 ~~~~~~~~~~
@@ -89,15 +97,61 @@ all-to-all
      :width: 200px
      :align: center
 
-Each node in ``pre`` is connected to every node in ``post``. Since
-``all_to_all`` is the default, 'rule' doesn't need to specified.
+Each node in ``A`` is connected to every node in ``B``. Since
+``all_to_all`` is the default, the rule doesn't actually have to be
+specified.
 
 ::
 
     n, m = 10, 12
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', m)
-    nest.Connect(A, B)
+    nest.Connect(A, B, 'all-to-all')
+    nest.Connect(A, B)  # equivalent
+
+.. _conn_builder_conngen:
+
+conngen
+~~~~~~~
+
+.. admonition:: Availability
+
+   This connection rule is only available if NEST was compiled with
+   :ref:`support for libneurosim <compile_with_libneurosim>`.
+
+To allow the generation of connectivity by means of an external
+library, NEST supports the Connection Generator Interface [1]_. For
+more details on this interface, see the Git repository of `libneurosim
+<https://github.com/INCF/libneurosim>`_.
+
+In contrast to the other rules for creating connections, this rule
+relies on a Connection Generator object to describe the connectivity
+pattern in a library-specific way. The Connection Generator is handed
+to ``Connect()`` under the key `cg` of the connection specification
+dictionary and evaluated internally. If the Connection Generator
+provides values for connection weights and delays, their respective
+indices can be specified under the key `params_map`.
+
+The following listing shows an example for using the `Connection-Set
+Algebra <https://github.com/INCF/csa>`_ in NEST via the Connection
+Generator Interface and randomly connects 10% of the neurons from
+``pre`` to the neurons in ``post``, each connection having a weight of
+10000.0 pA and a delay of 1.0 ms:
+
+::
+
+   pre = nest.Create('iaf_psc_alpha', 100)
+   post = nest.Create('iaf_psc_alpha', 100)
+
+   # Create the Connection Generator object
+   import csa
+   cg = csa.cset(csa.random(0.1), 10000.0, 1.0)
+
+   # Map weight and delay indices to vaules from cg
+   params_map = {'weight': 0, 'delay': 1}
+
+   conn_dict = {'rule': 'conngen', 'cg': cg, 'params_map': params_map}
+   nest.Connect(pre, post, conn_dict)
 
 fixed indegree
 ~~~~~~~~~~~~~~
@@ -106,8 +160,8 @@ fixed indegree
      :width: 200px
      :align: center
 
-The nodes in ``pre`` are randomly connected with the nodes in ``post``
-such that each node in ``post`` has a fixed ``indegree``.
+The nodes in ``A`` are randomly connected with the nodes in ``B`` such
+that each node in ``B`` has a fixed `indegree` of ``N``.
 
 ::
 
@@ -124,8 +178,8 @@ fixed outdegree
      :width: 200px
      :align: center
 
-The nodes in ``pre`` are randomly connected with the nodes in ``post``
-such that each node in ``pre`` has a fixed ``outdegree``.
+The nodes in ``A`` are randomly connected with the nodes in ``B`` such
+that each node in ``A`` has a fixed `outdegree` of ``N``.
 
 ::
 
@@ -156,8 +210,9 @@ one-to-one
      :width: 200px
      :align: center
 
-The ith node in ``pre`` is connected to the ith node in ``post``. The
-NodeCollections of ``pre`` and ``post`` have to be of the same length.
+The `i`th node in ``A`` is connected to the `i`th node in ``B``. The
+NodeCollections of ``A`` and ``B`` have to contain the same number of
+nodes.
 
 ::
 
@@ -169,8 +224,8 @@ NodeCollections of ``pre`` and ``post`` have to be of the same length.
 pairwise bernoulli
 ~~~~~~~~~~~~~~~~~~
 
-For each possible pair of nodes from ``pre`` and ``post``, a connection
-is created with probability ``p``.
+For each possible pair of nodes from ``A`` and ``B``, a connection is
+created with probability ``p``.
 
 ::
 
@@ -183,97 +238,63 @@ is created with probability ``p``.
 symmetric pairwise bernoulli
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For each possible pair of nodes from ``pre`` and ``post``, a connection
-is created with probability ``p`` from ``pre`` to ``post``, as well as
-a connection from ``post`` to ``pre`` (two connections in total). To
-use the 'symmetric_pairwise_bernoulli' rule, ``allow_autapses`` must
-be `False`, and ``make_symmetric`` must be `True`.
+For each possible pair of nodes from ``A`` and ``B``, a connection is
+created with probability ``p`` from ``A`` to ``B``, as well as a
+connection from ``B`` to ``A`` (two connections in total). To use the
+'symmetric_pairwise_bernoulli' rule, ``allow_autapses`` must be
+`False`, and ``make_symmetric`` must be `True`.
 
 ::
 
-    n, m, p = 10, 12, 0.2 
-    A = nest.Create('iaf_psc_alpha', n) 
-    B = nest.Create('iaf_psc_alpha', m) 
-    conn_dict = {'rule': 'symmetric_pairwise_bernoulli', 'p': p, 'allow_autapses': False, 'make_symmetric': True} 
+    n, m, p = 10, 12, 0.2
+    A = nest.Create('iaf_psc_alpha', n)
+    B = nest.Create('iaf_psc_alpha', m)
+    conn_dict = {'rule': 'symmetric_pairwise_bernoulli', 'p': p,
+                 'allow_autapses': False, 'make_symmetric': True}
     nest.Connect(A, B, conn_dict)
-
-.. _conn_builder_conngen:
-    
-conngen
-~~~~~~~
-
-.. admonition:: Availability
-
-   This connection rule is only available if NEST was compiled with
-   :ref:`support for libneurosim <compile_with_libneurosim>`.
-
-To allow the generation of connectivity by means of an external
-library, NEST supports the Connection Generator Interface [1]_.
-
-In contrast to the other rules for creating connections, this rule
-relies on a Connection Generator object, in which the connectivity
-pattern is specified in a library-specific way. The Connection
-Generator is then handed to the call to ``Connect`` and evaluated
-internally. For more details, please see the Git repository of
-`libneurosim <https://github.com/INCF/libneurosim>`_.
-
-The following code shows an example for using the `Connection-Set
-Algebra <https://github.com/INCF/csa>`_ in NEST via the Connection
-Generator Interface to create random connectivity between two groups
-of neurons, each having a weight of 10000.0 pA and a delay of 1.0 ms:
-
-::
-
-   sources = nest.Create('iaf_psc_alpha', 100)
-   targets = nest.Create('iaf_psc_alpha', 100)
-
-   # Create the Connection Generator object
-   import csa
-   cg = csa.cset(csa.random(0.1), 10000.0, 1.0)
-
-   # Map weight and delay indices to vaules from cg
-   params_map = {'weight': 0, 'delay': 1}
-
-   connspec = {'rule': 'conngen', 'cg': cg, 'params_map': params_map}
-   nest.Connect(pre, post, connspec)
 
 .. _synapse_spec:
 
 Synapse Specification
 ---------------------
 
-The synapse properties can be given as a string, a ``CollocatedSynapse``
-object, or a dictionary. The string can be the name of a pre-defined
-synapse which can be found in the synapsedict (see :ref:`synapse-types`)
-or a manually defined synapse via ``CopyModel()``.
+The synapse properties can be given as just the name of the desired
+synapse model as a string, a ``CollocatedSynapse`` object, or a
+dictionary specifying the synapse parameters in more detail.
 
 ::
 
     n = 10
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', n)
-    nest.CopyModel('static_synapse','excitatory',{'weight': 2.5, 'delay': 0.5})
-    nest.Connect(A, B, syn_spec='excitatory')
+    nest.Connect(A, B, syn_spec='static_synapse')
+    
+    syn_spec_dict = {'synapse_model': 'stdp_synapse', 'weight': 2.5, 'delay': 0.5})
+    nest.Connect(A, B, syn_spec=syn_spec_dict)
 
-Specifying the synapse properties in a dictionary allows for distributed
-synaptic parameters. In addition to the key ``synapse_model``, the dictionary can
-contain specifications for ``weight``, ``delay``, ``receptor_type`` and
-parameters specific to the chosen synapse model. The specification of
-all parameters is optional. Unspecified parameters will use the default
-values determined by the current synapse model. These default values can be inspected
-with ``nest.GetDefaults(synapse_model)``. All parameters can be
-scalars, arrays or distributions (specified as a ``nest.Parameter``). One
-synapse dictionary can contain an arbitrary combination of parameter
-types, as long as they agree with the connection routine (``rule``).
+Specifying the synapse properties as a collocated synapses or in a
+single dictionary allows to draw synaptic parameters from random
+distributions and combine such parameters flexibly. In addition to the
+key ``synapse_model``, the dictionary can contain specifications for
+``weight``, ``delay``, ``receptor_type`` (see :ref:`receptor-types`
+for details) and parameters specific to the chosen synapse model. The
+specification of all parameters is optional and unspecified parameters
+will take on the default values of the chosen synapse model. These
+defaults can be inspected using ``nest.GetDefaults(synapse_model)``.
+
+All parameters can be either scalars, arrays or distributions
+(specified as a ``nest.Parameter``). One synapse dictionary can
+contain an arbitrary combination of parameter types, as long as they
+are in agreement with the chosen connection rule.
 
 Scalar parameters
 ~~~~~~~~~~~~~~~~~
 
-Scalar parameters must be given as floats except for the
-`receptor_type` which has to be of type integer. For more
-information on the receptor type see :ref:`receptor-types`. When a synapse
-parameter is given as a scalar, the value will be applied to all connections
-created with the current ``Connect()`` call.
+Scalar parameters must be given with the correct type. The `weight`
+for instance must be a float, while the `receptor_type` has to be of
+type integer. When a synapse parameter is given as a scalar, the value
+will be applied to all connections created in the current
+``Connect()`` call.
 
 ::
 
@@ -281,103 +302,105 @@ created with the current ``Connect()`` call.
     neuron_dict = {'tau_syn': [0.3, 1.5]}
     A = nest.Create('iaf_psc_exp_multisynapse', n, neuron_dict)
     B = nest.Create('iaf_psc_exp_multisynapse', n, neuron_dict)
-    syn_dict ={'synapse_model': 'static_synapse', 'weight': 2.5, 'delay': 0.5, 'receptor_type': 1}
-    nest.Connect(A, B, syn_spec=syn_dict)
+    syn_spec_dict ={'synapse_model': 'static_synapse', 'weight': 2.5, 'delay': 0.5, 'receptor_type': 1}
+    nest.Connect(A, B, syn_spec=syn_spec_dict)
 
 Array parameters
 ~~~~~~~~~~~~~~~~
 
-Array parameters can be used in conjunction with the rules
-``all_to_all``, ``fixed_indegree``, ``fixed_outdegree``, ``fixed_total_number``
-and ``one_to_one``. The arrays can be specified as NumPy arrays or
-lists. As with the scalar parameters, all parameters but the receptor
-types must be specified as arrays of floats.
+Array parameters can be used with the rules ``all_to_all``,
+``fixed_indegree``, ``fixed_outdegree``, ``fixed_total_number`` and
+``one_to_one``. The arrays can be specified as NumPy arrays or Python
+lists. As with the scalar parameters, all parameters have to be
+specified as arrays of the correct type.
 
 all-to-all
 ^^^^^^^^^^
 
-When connecting using ``all_to_all``, the array must be of dimension
-`len(post) x len(pre)`.
+When connecting ``all_to_all``, the array parameter must have
+dimension `len(post) x len(pre)`.
 
 ::
 
     A = nest.Create('iaf_psc_alpha', 3)
     B = nest.Create('iaf_psc_alpha', 2)
-    syn_dict = {'weight': [[1.2, -3.5, 2.5],[0.4, -0.2, 0.7]]}
-    nest.Connect(A, B, syn_spec=syn_dict)
+    syn_spec_dict = {'weight': [[1.2, -3.5, 2.5], [0.4, -0.2, 0.7]]}
+    nest.Connect(A, B, syn_spec=syn_spec_dict)
 
 fixed indegree
 ^^^^^^^^^^^^^^
 
-For ``fixed_indegree`` the array has to be a two-dimensional NumPy array
-or list with shape `(len(post), indegree)`, where indegree is the number of
-incoming connections per target neuron. Therefore, the rows describe the
-target and the columns the connections converging to the target neuron,
-regardless of the identity of the source neurons.
+For rule ``fixed_indegree`` the array has to be a two-dimensional
+NumPy array or Python list with shape `(len(post), indegree)`, where
+`indegree` is the number of incoming connections per target neuron.
+This means that the rows describe the target, while the columns
+represent the connections converging on the target neuron, regardless
+of the identity of the source neurons.
 
 ::
 
     A = nest.Create('iaf_psc_alpha', 5)
     B = nest.Create('iaf_psc_alpha', 3)
-    conn_dict = {'rule': 'fixed_indegree', 'indegree': 2}
-    syn_dict = {'weight': [[1.2, -3.5],[0.4, -0.2],[0.6, 2.2]]}
-    nest.Connect(A, B, conn_spec=conn_dict, syn_spec=syn_dict)
+    conn_spec_dict = {'rule': 'fixed_indegree', 'indegree': 2}
+    syn_spec_dict = {'weight': [[1.2, -3.5],[0.4, -0.2],[0.6, 2.2]]}
+    nest.Connect(A, B, conn_spec_dict, syn_spec_dict)
 
 fixed outdegree
 ^^^^^^^^^^^^^^^
 
-For ``fixed_outdegree`` the array has to be a two-dimensional NumPy array
-or list with shape `(len(pre), outdegree)`, where outdegree is the number of
-outgoing connections per source neuron. Therefore, the rows describe the
-source and the columns the connections starting from the source neuron
+For rule ``fixed_outdegree`` the array has to be a two-dimensional
+NumPy array or Python list with shape `(len(pre), outdegree)`, where
+`outdegree` is the number of outgoing connections per source
+neuron. This means that the rows describe the source, while the
+columns represent the connections starting from the source neuron
 regardless of the identity of the target neuron.
 
 ::
 
     A = nest.Create('iaf_psc_alpha', 2)
     B = nest.Create('iaf_psc_alpha', 5)
-    conn_dict = {'rule': 'fixed_outdegree', 'outdegree': 3}
-    syn_dict = {'weight': [[1.2, -3.5, 0.4], [-0.2, 0.6, 2.2]]}
-    nest.Connect(A, B, conn_spec=conn_dict, syn_spec=syn_dict)
+    conn_spec_dict = {'rule': 'fixed_outdegree', 'outdegree': 3}
+    syn_spec_dict = {'weight': [[1.2, -3.5, 0.4], [-0.2, 0.6, 2.2]]}
+    nest.Connect(A, B, conn_spec_dict, syn_spec_dict)
 
 fixed total number
 ^^^^^^^^^^^^^^^^^^
 
-For ``fixed_total_number``, the array has to be same the length as the
+For rule ``fixed_total_number``, the array has to be same the length as the
 number of connections ``N``.
 
 ::
 
     A = nest.Create('iaf_psc_alpha', 3)
     B = nest.Create('iaf_psc_alpha', 4)
-    conn_dict = {'rule': 'fixed_total_number', 'N': 4}
-    syn_dict = {'weight': [1.2, -3.5, 0.4, -0.2]}
-    nest.Connect(A, B, conn_dict, syn_dict)
+    conn_spec_dict = {'rule': 'fixed_total_number', 'N': 4}
+    syn_spec_dict = {'weight': [1.2, -3.5, 0.4, -0.2]}
+    nest.Connect(A, B, conn_spec_dict, syn_spec_dict)
 
 one-to-one
 ^^^^^^^^^^
 
-For ``one_to_one`` the array must have the same length as the NodeCollections.
+For rule ``one_to_one`` the array must have the same length as there
+are nodes in ``A`` and ``B``.
 
 ::
 
     A = nest.Create('iaf_psc_alpha', 2)
     B = nest.Create('spike_recorder', 2)
-    conn_dict = {'rule': 'one_to_one'}
-    syn_dict = {'weight': [1.2, -3.5]}
-    nest.Connect(A, B, conn_dict, syn_dict)
-
+    conn_spec_dict = {'rule': 'one_to_one'}
+    syn_spec_dict = {'weight': [1.2, -3.5]}
+    nest.Connect(A, B, conn_spec_dict, syn_spec_dict)
 
 .. _dist_params:
 
 Distributed parameters
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Distributed parameters are given as ``nest.Parameter`` objects that represent
-values drawn from random distributions. These distributions can either be based on
-spatial node parameters, on default values, or on constant distribution values
-you provide. It is possible to combine the parameters to create distributions
-tailor made for your needs.
+Distributed parameters are given as ``nest.Parameter`` objects that
+represent values drawn from random distributions. These distributions
+can either be based on spatial node parameters, on default values, or
+on constant distribution values you provide. It is possible to combine
+parameters to create distributions tailor made for your needs.
 
 The following parameters and functionalities are provided:
 
@@ -388,31 +411,34 @@ The following parameters and functionalities are provided:
 - Clipping, redrawing, and conditional parameters
 
 For more information, check out the documentation on the different
-:doc:`PyNEST APIs <../ref_material/pynest_apis>` or this section on :ref:`parametrization <param_ex>`.
+:doc:`PyNEST APIs <../ref_material/pynest_apis>` or this section on
+:ref:`parametrization <param_ex>`.
 
 ::
 
     n = 10
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', n)
-    syn_dict = {'synapse_model': 'stdp_synapse',
-                'weight': 2.5,
-                'delay': nest.random.uniform(min=0.8, max=2.5),
-                'alpha': nest.math.redraw(nest.random.normal(mean=5.0, std=1.0), min=0.5, max=10000.)
-               }
-    nest.Connect(A, B, syn_spec=syn_dict)
+    syn_spec_dict = {
+        'synapse_model': 'stdp_synapse',
+        'weight': 2.5,
+        'delay': nest.random.uniform(min=0.8, max=2.5),
+        'alpha': nest.math.redraw(nest.random.normal(mean=5.0, std=1.0), min=0.5, max=10000.)
+    }
+    nest.Connect(A, B, syn_spec=syn_spec_dict)
 
-In this example, the ``all_to_all`` connection rule is applied by
-default, using the `stdp_synapse` model. All synapses are created with
-weight 2.5, a delay uniformly distributed in [0.8, 2.5], while the alpha
-parameters are drawn from a normal distribution with mean 5.0 and standard
-deviation 1.0; values below 0.5 are excluded by re-drawing any values
-below 0.5. We have set the ``max`` value of ``nest.math.redraw`` to be a
-large number, so it is in principle never reached. Thus, the actual distribution
-is a slightly distorted Gaussian.
+In this example, the default connection rule ``all_to_all`` is used
+and connections will be using the model `stdp_synapse`. All synapses
+are created with a static weight of 2.5 and a delay that is uniformly
+distributed in [0.8, 2.5]. The parameter `alpha` is drawn from a
+normal distribution with mean 5.0 and standard deviation 1.0, however,
+values below 0.5 are excluded by re-drawing if they should occur. By
+setting the ``max`` value of ``nest.math.redraw`` to be a large
+number, we make sure that this value is never hit in reality. Thus,
+the actual distribution is a slightly distorted Gaussian.
 
-If the synapse is supposed to have a unique name and distributed
-parameters, it needs to be defined in two steps:
+If the synapse type is supposed to have a unique name and still use
+distributed parameters, it needs to be defined in two steps:
 
 ::
 
@@ -420,78 +446,82 @@ parameters, it needs to be defined in two steps:
     A = nest.Create('iaf_psc_alpha', n)
     B = nest.Create('iaf_psc_alpha', n)
     nest.CopyModel('stdp_synapse','excitatory',{'weight':2.5})
-    syn_dict = {'synapse_model': 'excitatory',
-                'weight': 2.5,
-                'delay': nest.random.uniform(min=0.8, max=2.5),
-                'alpha': nest.math.redraw(nest.random.normal(mean=5.0, std=1.0), min=0.5, max=10000.)
-               }
+    syn_dict = {
+        'synapse_model': 'excitatory',
+        'weight': 2.5,
+        'delay': nest.random.uniform(min=0.8, max=2.5),
+        'alpha': nest.math.redraw(nest.random.normal(mean=5.0, std=1.0), min=0.5, max=10000.)
+    }
     nest.Connect(A, B, syn_spec=syn_dict)
 
-For further information on the distributions see :doc:`Random numbers in
-NEST <random_numbers>`.
-
+For further information on the available distributions see
+:doc:`Random numbers in NEST <random_numbers>`.
 
 .. _collocated_synapses:
 
 Collocated synapses
 ~~~~~~~~~~~~~~~~~~~
 
-It is also possible to create several connections with different synapses simultaneously. The different synapse dictionaries will
-then be applied to each source-target pair. To create these collocated synapses, ``CollocatedSynapses()`` must be used
-as the syn_spec argument of ``Connect``, instead of the usual syn_spec dictionary argument. ``CollocatedSynapses()``
-takes synapse dictionaries as arguments.
+Sometimes it is useful to create several connections with different
+synapse types simultaneously. To create such `collocated synapses`, an
+object of type ``CollocatedSynapses`` must be used as the ``syn_spec``
+in the call to ``Connect``. The constructor ``CollocatedSynapses()``
+takes synapse specification dictionaries as arguments and the given
+dictionaries will be applied to each source-target pair.
 
   ::
 
     nodes = nest.Create('iaf_psc_alpha', 3)
-    syn_spec = nest.CollocatedSynapses({'weight': 4., 'delay': 1.5},
+    syn_spec = nest.CollocatedSynapses({'weight': 4.0, 'delay': 1.5},
                                        {'synapse_model': 'stdp_synapse'},
-                                       {'synapse_model': 'stdp_synapse', 'alpha': 3.})
+                                       {'synapse_model': 'stdp_synapse', 'alpha': 3.0})
     nest.Connect(nodes, nodes, conn_spec='one_to_one', syn_spec=syn_spec)
+    print(nest.GetConnections().alpha)
 
-    conns = nest.GetConnections()
-    print(conns.alpha)
-
-This will create 9 connections: 3 using `static_synapse` with a `weight` of `4.0` and `delay` of `1.5`, and 6 using
-the `stdp_synapse`. Of the 6 using `stdp_synapse`, 3 will have the default alpha value, and 3 will have an alpha of
-`3.0`.
+The example above will create 9 connections in total.
+* 3 use the default model ``static_synapse`` with a `weight` of 4.0
+  and `delay` of 1.5
+* 6 use the model `stdp_synapse`. Of these,
+  * 3 will have the default value for parameter `alpha`
+  * 3 will have an `alpha` of 3.0.
 
   >>> print(nest.GetKernelStatus('num_connections'))
   9
 
-If you want to connect with different :ref:`receptor types <receptor-types>`, you can do the following:
+If you want to connect with different :ref:`receptor types
+<receptor-types>`, you can do the following:
 
   ::
 
-    src = nest.Create('iaf_psc_exp_multisynapse', 7)
-    trgt = nest.Create('iaf_psc_exp_multisynapse', 7, {'tau_syn': [0.1 + i for i in range(7)]})
+    A = nest.Create('iaf_psc_exp_multisynapse', 7)
+    B = nest.Create('iaf_psc_exp_multisynapse', 7, {'tau_syn': [0.1 + i for i in range(7)]})
+    syn_spec_dict = nest.CollocatedSynapses({'weight': 5.0, 'receptor_type': 2},
+                                            {'weight': 1.5, 'receptor_type': 7})
+    nest.Connect(A, B, 'one_to_one', syn_spec_dict)
+    print(nest.GetConnections().get())
 
-    syn_spec = nest.CollocatedSynapses({'weight': 5.0, 'receptor_type': 2},
-                                       {'weight': 1.5, 'receptor_type': 7})
-
-    nest.Connect(src, trgt, 'one_to_one', syn_spec=syn_spec)
-
-    conns = nest.GetConnections()
-    print(conns.get())
-
-You can see how many synapse parameters you have by calling `len()` on your `CollocatedSynapses` object:
+You can see how many synapse parameters you have by calling `len()` on
+your `CollocatedSynapses` object:
 
   >>> len(syn_spec)
   2
 
-
 Spatially-structured networks
 -----------------------------
 
-If nodes are created with spatial distributions, it is possible to create connections with
-attributes based on node positions. See :doc:`Spatially-structured networks <spatial/index>`
-for more information.
+If nodes are created so that they have a spatial arrangement, it is
+possible to create connections with attributes based on the nodes'
+positions. See :doc:`Spatially-structured networks <spatial/index>`
+for more information about how to create such networks.
 
 Connecting sparse matrices with array indexing
 ----------------------------------------------
 
-One may want to generate connections from a sparse matrix of connection weights.
-Assume we have a weight matrix of the form:
+Oftentimes, you will find yourself in a situation, where you want to
+base your connectivity on actual data instead of on rules. A common
+situation here is that you have a (sometimes sparse) connection matrix
+coming from an experiment or from a graph algorithm. Let's assume you
+have a weight matrix of the form:
 
 .. math::
 
@@ -502,43 +532,47 @@ Assume we have a weight matrix of the form:
     w_{1m} & w_{2m} & \cdots & w_{nm} \\
     \end{bmatrix}
 
-where :math:`w_{ij}` is the weight of the connection with presynaptic node :math:`i`
-and postsynaptic node :math:`j`. We can assume that some weights are zero. Instead of
-creating connections with zero weight in these cases, we want to not create these
-connections at all.
+where :math:`w_{ij}` is the weight of the connection with presynaptic
+node :math:`i` and postsynaptic node :math:`j`. In all generality, we
+can assume that some weights are zero, indicating that there is no
+connection at all.
 
-There is currently no way to create connections from the whole matrix in one go, so we
-will iterate the presynaptic neurons and connect one column at a time. We assume
-that we have :math:`n` presynaptic and :math:`m` postsynaptic nodes in the NodeCollections
-`presynaptic` and `postsynaptic`, respectively. We also assume that we have a weight matrix
-as a two-dimensional NumPy array `W`, with :math:`n` columns and :math:`m` rows.
+As there is no support for creating connections from the whole matrix
+directly, we will instead just iterate the presynaptic neurons and
+connect one column at a time. We assume that there are :math:`n`
+presynaptic nodes in the NodeCollection ``A`` and :math:`m`
+postsynaptic nodes in ``B``. We also assume that we have our weight
+matrix given as a two-dimensional NumPy array `W`, with :math:`n`
+columns and :math:`m` rows.
 
 ::
 
-    W = np.array([[0.5, 0., 1.5],
-                  [1.3, 0.2, 0.],
-                  [0., 1.25, 1.3]])
+    W = np.array([[0.5 , 0.0, 1.5],
+                  [1.3 , 0.2, 0.0],
+                  [0.0, 1.25, 1.3]])
 
-    presynaptic = nest.Create('iaf_psc_alpha', 3)
-    postsynaptic = nest.Create('iaf_psc_alpha', 3)
+    A = nest.Create('iaf_psc_alpha', 3)
+    B = nest.Create('iaf_psc_alpha', 3)
 
-    for i, pre in enumerate(presynaptic):
+    for i, pre in enumerate(A):
         # Extract the weights column.
         weights = W[:, i]
 
-        # To only connect pairs with a nonzero weight,
-        # we use array indexing to extract the weights and postsynaptic neurons.
+        # To only connect pairs with a nonzero weight, we use array
+	# indexing to extract the weights and postsynaptic neurons.
         nonzero_indices = numpy.where(weights != 0)[0]
         weights = weights[nonzero_indices]
-        post = postsynaptic[nonzero_indices]
+        post = B[nonzero_indices]
 
-        # Generate an array of node IDs for the column of the weight matrix, with length based on the
-        # number of nonzero elements. dtype must be an integer.
-        pre_array = numpy.ones(len(nonzero_indices), dtype=numpy.int64)*pre.get('global_id')
+        # Generate an array of node IDs for the column of the weight
+	# matrix, with length based on the number of nonzero
+	# elements. The array's dtype must be an integer.
+        pre_array = numpy.ones(len(nonzero_indices), dtype=numpy.int64) * pre.get('global_id')
 
-        # nest.Connect() automatically converts post to a NumPy array because pre_array
-        # contains multiple identical node IDs. When also specifying a one_to_one connection rule,
-        # the arrays of node IDs can then be connected.
+        # nest.Connect() automatically converts post to a NumPy array
+	# because pre_array contains multiple identical node IDs. When
+	# also specifying a one_to_one connection rule, the arrays of
+	# node IDs can then be connected.
         nest.Connect(pre_array, post, conn_spec='one_to_one', syn_spec={'weight': weights})
 
 .. _receptor-types:
@@ -546,18 +580,26 @@ as a two-dimensional NumPy array `W`, with :math:`n` columns and :math:`m` rows.
 Receptor Types
 --------------
 
-Each connection in NEST targets a specific receptor type on the
-postsynaptic node. Receptor types are identified by integer numbers,
-the default receptor type is 0. The meaning of the receptor type depends
-on the model and is documented in the model documentation. To connect to
-a non-standard receptor type, the parameter ``receptor_type`` of the
-``syn_spec`` argument is used in the call to the ``Connect``
-command. To illustrate the concept of receptor types, we give an example
-using standard integrate-and-fire neurons as presynaptic nodes and a
-multi-compartment integrate-and-fire neuron (``iaf_cond_alpha_mc``) as
-postsynaptic node. As seen in the image and code snippet below, we
-connect the integrate-and-fire neurons to different receptors of the
-multi-compartment integrate-and-fire neuron model.
+Conceptually, each connection in NEST terminates at a `receptor` on
+the target node. The exact meaning of such a receptor depends on the
+concrete type of that node. In a multi-compartment neuron, for
+instance, the different compartments could be addressed as different
+receptors, while another neuron model might make sets of different
+synaptic parameters available for each receptor. Please refer to the
+:doc:`model documentation <../models/index_neuron>` for details.
+
+In order to connect a pre-synaptic node to a certain receptor on a
+post-synaptic node, the integer ID of the receptor is given under the
+key ``receptor_type`` in the ``syn_spec`` dictionary when calling
+``Connect()``. If unspecified, the receptor will take on its default
+of 0. If you request a receptor that is not available in the target
+node, this will result in an error.
+
+To illustrate the concept of receptors in more detail, the following
+example shows how to connect several ``iaf_psc_alpha`` neurons to the
+different compartments of a multi-compartment integrate-and-fire
+neuron (``iaf_cond_alpha_mc``) that are represented by different
+receptors.
 
 .. image:: ../_static/img/Receptor_types.png
      :width: 200px
@@ -588,24 +630,27 @@ multi-compartment integrate-and-fire neuron model.
     nest.Connect(A3, B, syn_spec={'receptor_type': receptors['proximal_exc']})
     nest.Connect(A4, B, syn_spec={'receptor_type': receptors['soma_inh']})
 
-In the example above, we inspect the receptor types of the model by calling
-``nest.GetDefaults('iaf_cond_alpha_mc')['receptor_types']``. This is not always
-possible however. For some models, like `iaf_psc_exp_multisynapse`, you have
-to create the receptors with the time constant ``tau_syn`` when creating the
-neurons. It is therefore not possible to inspect the receptors beforehand. The
-`trgt` neuron below for instance, will have 3 receptors, and we can connect to
-the different receptors when creating. The source neuron on the other hand,
-which is of the same model, does not have any receptors. You can inspect the
-number of receptors by looking up ``n_synapses`` on the `trgt` NodeCollection.
+In the example above, we inspect the receptors of the model by calling
+``nest.GetDefaults('iaf_cond_alpha_mc')['receptor_types']``.  This
+functionality is, however, only available for models with a predefined
+number of receptors, while models with a variable number of receptors
+usually don't provide such an enumeration.
+
+An example for the latter are the `*_multisynapse` neuron models that
+support multiple individual synaptic time constants for the different
+receptors. In these models, the number of available receptors is
+determined by the length of the ``tau_syn`` vector that is supplied to
+the model instance. The following code snippet shows the setup and
+connection of such a model in more detail:
 
   ::
 
-    src = nest.Create('iaf_psc_exp_multisynapse', 7)
-    trgt = nest.Create('iaf_psc_exp_multisynapse', 7, {'tau_syn': [0.1, 0.2, 0.3]})
+    A = nest.Create('iaf_psc_alpha')
+    B = nest.Create('iaf_psc_exp_multisynapse', params={'tau_syn': [0.1, 0.2, 0.3]})
 
-    print(trgt.n_synapses)
+    print(B.n_synapses)
 
-    nest.Connect(src, trgt, 'one_to_one', syn_spec={'receptor_type': 2})
+    nest.Connect(A, B, syn_spec={'receptor_type': 2})
 
 
 .. _synapse-types:
@@ -613,102 +658,55 @@ number of receptors by looking up ``n_synapses`` on the `trgt` NodeCollection.
 Synapse Types
 -------------
 
-NEST supports multiple synapse types that can be specified during
-connection setup. The default synapse type in NEST is the
-``static_synapse``. Its weight does not change over time. To allow
-learning and plasticity, it is possible to use other synapse types that
-implement long-term or short-term plasticity. A list of available types
-is accessible via the command ``nest.Models('synapses')``. The output of this
-command (as of commit `b08590a <https://github.com/nest/nest-simulator/tree/b08590af6d721ab66f8a72dcde053cff00d56512>`_)
-is shown below:
+NEST provides a number of built-in synapse models that can be used
+during connection setup. The default model is the ``static_synapse``,
+whose only parameters `weight` and `delay` do not change over time.
+Other synapse types model effects like learning and adaptation in the
+form of long-term or short-term plasticity. A list of available
+synapse models is accessible via the command
+``nest.Models('synapses')``. A list of available synapse models and
+more detailed information about each of them can be found in the
+:doc:`model directory <../models/index_synapse>`.
 
-::
+.. note::
+   Not all nodes can be connected via all available synapse types. The
+   events a synapse type is able to transmit is documented in the
+   ``Transmits`` section of the model documentation.
+     
+All synapses store their parameters on a per-connection basis.
+However, each of the built-in models is registered with the simulation
+kernel in a number of different ways that slightly modify the
+available properties of the connections instantiated from the model.
+The different variants are indicated by specific suffixes:
 
-    ['bernoulli_synapse',
-     'bernoulli_synapse_hpc',
-     'bernoulli_synapse_lbl',
-     'clopath_synapse',
-     'clopath_synapse_hpc',
-     'clopath_synapse_lbl',
-     'cont_delay_synapse',
-     'cont_delay_synapse_hpc',
-     'cont_delay_synapse_lbl',
-     'diffusion_connection',
-     'diffusion_connection_lbl',
-     'gap_junction',
-     'gap_junction_lbl',
-     'ht_synapse',
-     'ht_synapse_hpc',
-     'ht_synapse_lbl',
-     'jonke_synapse',
-     'jonke_synapse_hpc',
-     'jonke_synapse_lbl',
-     'quantal_stp_synapse',
-     'quantal_stp_synapse_hpc',
-     'quantal_stp_synapse_lbl',
-     'rate_connection_delayed',
-     'rate_connection_delayed_lbl',
-     'rate_connection_instantaneous',
-     'rate_connection_instantaneous_lbl',
-     'static_synapse',
-     'static_synapse_hom_w',
-     'static_synapse_hom_w_hpc',
-     'static_synapse_hom_w_lbl',
-     'static_synapse_hpc',
-     'static_synapse_lbl',
-     'stdp_dopamine_synapse',
-     'stdp_dopamine_synapse_hpc',
-     'stdp_dopamine_synapse_lbl',
-     'stdp_facetshw_synapse_hom',
-     'stdp_facetshw_synapse_hom_hpc',
-     'stdp_facetshw_synapse_hom_lbl',
-     'stdp_nn_pre-centered_synapse',
-     'stdp_nn_pre-centered_synapse_hpc',
-     'stdp_nn_pre-centered_synapse_lbl',
-     'stdp_nn_restr_synapse',
-     'stdp_nn_restr_synapse_hpc',
-     'stdp_nn_restr_synapse_lbl',
-     'stdp_nn_symm_synapse',
-     'stdp_nn_symm_synapse_hpc',
-     'stdp_nn_symm_synapse_lbl',
-     'stdp_pl_synapse_hom',
-     'stdp_pl_synapse_hom_hpc',
-     'stdp_pl_synapse_hom_lbl',
-     'stdp_synapse',
-     'stdp_synapse_hom',
-     'stdp_synapse_hom_hpc',
-     'stdp_synapse_hom_lbl',
-     'stdp_synapse_hpc',
-     'stdp_synapse_lbl',
-     'stdp_triplet_synapse',
-     'stdp_triplet_synapse_hpc',
-     'stdp_triplet_synapse_lbl',
-     'tsodyks2_synapse',
-     'tsodyks2_synapse_hpc',
-     'tsodyks2_synapse_lbl',
-     'tsodyks_synapse',
-     'tsodyks_synapse_hom',
-     'tsodyks_synapse_hom_hpc',
-     'tsodyks_synapse_hom_lbl',
-     'tsodyks_synapse_hpc',
-     'tsodyks_synapse_lbl',
-     'urbanczik_synapse',
-     'urbanczik_synapse_hpc',
-     'urbanczik_synapse_lbl',
-     'vogels_sprekeler_synapse',
-     'vogels_sprekeler_synapse_hpc',
-     'vogels_sprekeler_synapse_lbl']
+.. glossary::
 
-All synapses store their parameters on a per-connection basis. An
-exception to this scheme are the homogeneous synapse types (identified
-by the suffix ``_hom``), which only store weight and delay once for all
-synapses of a type. This means that these are the same for all
-connections. They can be used to save memory.
+ ``_lbl``
+   denotes `labeled synapses` that have an additional parameter
+   `synapse_label` (type: int), which can be set to a user-defined
+   value. In a common application this label is used to store an
+   additional projection identifier. Please note that using this
+   synapse variant may drive up the memory requirements of your
+   simulations significantly, as the label is stored on a
+   `per-synapse` basis.
 
-The default values of a synapse type can be inspected using the command
-``nest.GetDefaults()``, which takes the name of the synapse as an argument,
-and modified with ``nest.SetDefaults()``, which takes the name of the synapse
-type and a parameter dictionary as arguments.
+ ``_hpc``
+   denotes `synapses for high-performance computing scenarios`, which
+   have minimal memory requirements by using thread-local target node
+   indices internally. Use this version if you are running very large
+   simulations.
+
+ ``_hom``
+   denotes `homogeneous synapses` that store certain parameters like
+   `weight` and `delay` only once for all synapses of the same type
+   and can thus be used to save memory.
+
+The default parameter values of a synapse model can be inspected using
+the command ``nest.GetDefaults()``, which only takes the name of the
+synapse model as an argument and returns a dictionary. Likewise, the
+function ``nest.SetDefaults()`` takes the name of a synapse type and a
+parameter dictionary as arguments and will modify the defaults of the
+given model.
 
 ::
 
@@ -720,16 +718,19 @@ type and a parameter dictionary as arguments.
          'receptor_type': 0,
          'requires_symmetric': False,
          'sizeof': 32,
-         'synapse_model':
-         'static_synapse',
+         'synapse_model': 'static_synapse',
          'weight': 1.0,
          'weight_recorder': ()}
 
     nest.SetDefaults('static_synapse', {'weight': 2.5})
 
-For the creation of custom synapse types from already existing synapse
-types, the command ``nest.CopyModel`` is used. It has an optional argument
-``params`` to directly customize it during the copy operation. Otherwise
+To further customize the process of creating synapses, it is often
+useful to have the same basic synapse model available with different
+parametizations. To this end, ``nest.CopyModel()`` can be used to
+create custom synapse types from already existing synapse types. In
+the simplest case, it takes the names of the existing model and the
+copied type to be created. The optional argument ``params`` allows to
+directly customize the new type during the copy operation. If omitted,
 the defaults of the copied model are taken.
 
 ::
@@ -737,44 +738,42 @@ the defaults of the copied model are taken.
     nest.CopyModel('static_synapse', 'inhibitory', {'weight': -2.5})
     nest.Connect(A, B, syn_spec='inhibitory')
 
-.. note::
-   Not all nodes can be connected via all available synapse
-   types. The events a synapse type is able to transmit is documented in
-   the ``Transmits`` section of the model documentation.
-
-
 .. _inspecting_connections:
 
 Inspecting Connections
 ----------------------
 
-``nest.GetConnections(source=None, target=None, synapse_model=None,synapse_label=None)``
-returns a ``SynapseCollection`` object of identifiers for connections
-that match the given parameters. ``source`` and ``target`` need to be
-NodeCollections of node IDs, ``synapse_model`` is a string representing
-a synapse model. You can also give a ``synapse_label`` if you have 
-specified this when connecting. If `GetConnections` is called without
-parameters, all connections in the network are returned. If a NodeCollection of
-source neurons is given, only connections from these presynaptic
-neurons are returned. If a NodeCollection of target neurons is given, only
-connections to these postsynaptic neurons are returned. If a synapse
-model is given, only connections with this synapse type are returned.
-Any combination of source, target and model parameters is permitted.
+In order to assert that the instantiated network model actually looks
+like what was intended, it is oftentimes useful to inspect the
+connections in the network. For this, NEST provides the function
 
-Each connection in the SynapseCollection is represented by the
-following five entries: source node-id, target node-id, target-thread,
-synapse-id, and port.
+::
+   
+  nest.GetConnections(source=None, target=None, synapse_model=None, synapse_label=None)
 
-The result of ``nest.GetConnections`` can be given as an argument to the
-``nest.GetStatus`` function, or, better yet, by using the ``get()`` function
-on the SynapseCollection. This will return a dictionary with the
-parameters of the connections:
+This function returns a ``SynapseCollection`` object that contains the
+identifiers for connections that match the given filters.  ``source``
+and ``target`` are given as NodeCollections, ``synapse_model`` is the
+name of the model as a string and ``synapse_label`` is an integer
+identifier. Any combination of these parameters is permitted. If
+``nest.GetConnections()`` is called without parameters it returns all
+connections in the network.
+
+Internally, each connection in the SynapseCollection is represented by
+the following five entries: source node ID, target node ID, thread ID
+of the target, numeric synapse ID, and port.
+
+The result of ``nest.GetConnections()`` can be further processed by
+giving it as an argument to ``nest.GetStatus()``, or, better yet, by
+using the ``get()`` function on the SynapseCollection directly. Both
+ways will yield a dictionary with the parameters of the connections
+that match the filter criterions given to ``nest.GetConnections()``:
 
 ::
 
-    n1 = nest.Create('iaf_psc_alpha', 2)
-    n2 = nest.Create('iaf_psc_alpha')
-    nest.Connect(n1, n2)
+    A = nest.Create('iaf_psc_alpha', 2)
+    B = nest.Create('iaf_psc_alpha')
+    nest.Connect(A, B)
     conn = nest.GetConnections()
     print(conn.get())
 
@@ -789,9 +788,9 @@ parameters of the connections:
          'target_thread': [0, 0],
          'weight': [1.0, 1.0]}
 
-The ``get()`` function also takes a string or list of strings as arguments. You
-can thus retrieve specific parameters if you do not want to inspect the entire
-synapse dictionary:
+The ``get()`` function of a SynapseCollection can optionally also take
+a string or list of strings to only retrieve specific parameters. This
+is useful if you do not want to inspect the entire synapse dictionary:
 
   >>>  conn.get('weight')
        [1.0, 1.0]
@@ -799,69 +798,70 @@ synapse dictionary:
   >>>  conn.get(['source', 'target'])
        {'source': [1, 2], 'target': [3, 3]}
 
-Another way of retrieving specific parameters is by getting it directly from
-the SynapseCollection:
+Another way of retrieving specific parameters is by getting them
+directly from the SynapseCollection using the dot-notation:
 
-    >>>  conn.delay
-         [1.0, 1.0]
+  >>>  conn.delay
+       [1.0, 1.0]
 
-For :doc:`spatially distributed networks <spatial/index>`, you can access the distance between
-the source-target pairs by calling `distance` on your SynapseCollection.
+For :doc:`spatially distributed networks <spatial/index>`, you can
+access the distance between the source-target pairs by querying
+`distance` on your SynapseCollection.
 
->>>  spatial_conn.distance
-     (0.47140452079103173,
-      0.33333333333333337,
-      0.4714045207910317,
-      0.33333333333333337,
-      3.925231146709438e-17,
-      0.33333333333333326,
-      0.4714045207910317,
-      0.33333333333333326,
-      0.47140452079103157)
+  >>>  spatial_conn.distance
+       (0.47140452079103173,
+        0.33333333333333337,
+        0.4714045207910317,
+        0.33333333333333337,
+        3.925231146709438e-17,
+        0.33333333333333326,
+        0.4714045207910317,
+        0.33333333333333326,
+        0.47140452079103157)
 
-You can further examine the SynapseCollection by checking the length of the object
-or by printing it, which will return a table of source and target node IDs, synapse
-model, weight and delay:
+You can further examine the SynapseCollection by checking the length
+of it or by printing it to the terminal. The printout will be in the
+form of a table that lists source and target node IDs, synapse model,
+weight and delay:
 
   >>>  len(conn)
        2
   >>>  print(conn)
-        source   target   synapse model   weight   delay 
+        source   target   synapse model   weight   delay
        -------- -------- --------------- -------- -------
              1        3  static_synapse    1.000   1.000
              2        3  static_synapse    1.000   1.000
 
-A SynapseCollection can be indexed or sliced, if you only want to inspect a
-subset of the collection:
+A SynapseCollection can be indexed or sliced, if you only want to
+inspect a subset of the connections contained in it:
 
   >>>  print(conn[0:2:2])
-        source   target   synapse model   weight   delay 
+        source   target   synapse model   weight   delay
        -------- -------- --------------- -------- -------
              1        3  static_synapse    1.000   1.000
 
+Last, but not least, SynapseCollection can be iterated, to retrieve
+one connection at a time:
 
-By iterating the SynapseCollection, a single connection SynapseCollection is returned:
-
-  >>> for c in conn:
-  >>>     print(c.source)                                                                                                                                 
-      1
-      2
-
+  >>>  for c in conn:
+  >>>      print(c.source)
+       1
+       2
 
 Modifying Existing Connections
 ------------------------------
 
-To modify the connections of an existing connection, one has to first
-obtain handles to the connections by calling `GetConnections()`. These
-can then be given as arguments to the ``nest.SetStatus()`` function, or
-by using the ``set()`` function on the SynapseCollection:
+To modify the parameters of an existing connection, you first have to
+obtain handles to them using ``nest.GetConnections()``. These handles
+can then be given as arguments to the ``nest.SetStatus()`` function.
+or by using the ``set()`` function on the SynapseCollection directly:
 
 ::
 
     n1 = nest.Create('iaf_psc_alpha', 2)
     n2 = nest.Create('iaf_psc_alpha', 2)
     nest.Connect(n1, n2)
-    
+
     conn = nest.GetConnections()
     conn.set(weight=2.0)
 
@@ -878,21 +878,26 @@ by using the ``set()`` function on the SynapseCollection:
          'target_thread': [0, 0, 0, 0],
          'weight': [2.0, 2.0, 2.0, 2.0]}
 
-Updating a single parameter is done by calling ``set(parameter_name=parameter_value)``.
-You can use a single value, a list, or a ``nest.Parameter`` as value. If a single
-value is given, the value is set on all connections. If you use a list to set
-the parameter, the list needs to be the same length as the SynapseCollection.
+To update a single parameter of a connection or a set of connections,
+you can call the ``set()`` function of the SynapseCollection with the
+keyword argument ``parameter_name``. The value for this argument can
+be a single value, a list, or a ``nest.Parameter``. If a single value
+is given, the value is set on all connections. If you use a list to
+set the parameter, the list needs to be the same length as there are
+connections in the SynapseCollection.
 
   >>>  conn.set(weight=[4.0, 4.5, 5.0, 5.5])
 
-Just as you can retrieve several parameters at once with the ``get()`` function
-above, you can also set several parameters at once with
-``set(parameter_dictionary)``. Again, you can again use a single value, a list, or a
-``nest.Parameter`` as value. 
+Similar to how you can retrieve several parameters at once with the
+``get()`` function explained above, you can also set multiple
+parameters at once using ``set(parameter_dictionary)``. Again, the
+values of the dictionary can be a single value, a list, or a
+``nest.Parameter``.
 
   >>>  conn.set({'weight': [1.5, 2.0, 2.5, 3.0], 'delay': 2.0})
 
-You can also directly set parameters of your SynapseCollection:
+Finally, you can also directly set parameters on a SynapseCollection
+using the dot-notation:
 
   >>>  conn.weight = 5.
   >>>  conn.weight
@@ -901,8 +906,9 @@ You can also directly set parameters of your SynapseCollection:
   >>>  conn.delay
        [5.1, 5.2, 5.3, 5.4]
 
-Note that some parameters, like `source` and `target`, cannot be set. The documentation of a specific
-model will point out which parameters can be set and which are read-only.
+Note that some parameters like `source` and `target` are read-only and
+cannot be set. The documentation of a specific synapse model will
+point out which parameters can be set and which are read-only.
 
 References
 ----------


### PR DESCRIPTION
Here's my major update and rewrite of the connection management documentation as promised in https://github.com/nest/nest-simulator/pull/1834. In particular, I tried to make the language and code snippets more consistent and more user centric, but I took the liberty to also rewrite major parts of the text. Sorry for this being so massive!

Looking at the changeset is probably not very helpful here (although I recommend doing it anyway, if only to admire the sheer volume) and I suggest to review by giving the rendered version a thorough read over a big pot of tea or coffee instead ;-)

Here are some general remarks (mainly for @sarakonradi, @steffengraber, @terhorstd):
* How shall we write NodeCollection and SynapseCollection? Always as <code>\`\`typewriter\`\`</code>, <code>\`italic\`</code>, plain? This is massively inconsistent all over the documentation.
* We also need to be more consistent on when to use `:math:` when referring to mathematical variables and when to just use italics.
* How to refer to dictionary entities like `keys` and `values`? I propose to use <code>\`\`typewriter\`\`</code> for keys and <code>\`italic\`</code> for values and other variables.
* The situation regarding the first three points is quite messy throughout the whole documentation and I really think we need a guideline document for this the sooner the better. Or is this already existing and I missed it?
* I think we urgently need an automatic linking of all PyNEST functions that are mentioned throughout the documentation (e.g. <code>\`\`nest.Connect()\`\`</code> to the corresponding anchor in the [PyNEST API documentation](https://nest-simulator.readthedocs.io/en/latest/ref_material/pynest_apis.html). The absence of this functionality leads to heaps of redundancy and repetitive descriptions of the same thing over and over again.
* I think the style (as in CSS) for the glossary items looks totally out of place. Just have a look at where `_lbl`, `_hpc`, and `_hom` are defined in the document.

And some more specific ones about this guide (for @stinebuu, @hakonsbm, @heplesser)
* Should we drop the description of `Get`/`SetStatus` for SynapseCollections? I think get() and set() or the dot-notation are much nicer anyway
* I'd like to rename `receptor_type` to just `receptor`. I think that's more accurately describing the matter and I am not aware of a possible name clash.
* I never really know if I have to write `all_to_all` or `all-to-all`. The same also applies to basically all rules. The documentation even adds to the confusion because it uses the first when referring to the rule and the second (or using spaces instead of dashed) when referring to the concept. I propose to solve the problem by accepting all variants (i.e. treat `-`, `_` and ` ` equally) in the `ConnBuilder` and just do *the right thing*™ regardless. IMO the chance for collisions here is negligible.
* I kind of dislike the term *distributed parameters* and would prefer something like *randomized parameters* or similar. As I could not come up with something I *loved*, I did not make a corresponding change. Maybe you have a good idea on this?

Yes, I know this PR in @stinebuu's repository is probably the wrong place for all this. I just wanted to get this off my mind and will happily create a separate issue for this if you think that'd be better. 